### PR TITLE
Decouple logging with Logger interface, improve docs, and move logger code

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ Warn(msg string, args ...any)
 Error(msg string, args ...any)
 ```
 
-A convenience adapter for Go's slog is provided:
+A convenience adapter for Go's slog is provided, but you must pass a logger that implements the required methods (Debug, Info, Warn, Error):
 
 ```go
 // Wrap your slog.Logger with ecs.NewSlogAdapter
+// Your slog.Logger must implement Debug, Info, Warn, and Error methods.
 logger := ecs.NewSlogAdapter(slog.Default())
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,10 @@ Warn(msg string, args ...any)
 Error(msg string, args ...any)
 ```
 
-A convenience adapter for Go's slog is provided, but you must pass a logger that implements the required methods (Debug, Info, Warn, Error):
+A convenience adapter for Go's slog is provided. You can wrap any logger that implements the required methods (Debug, Info, Warn, Error):
 
 ```go
-// Wrap your slog.Logger with ecs.NewSlogAdapter
-// Your slog.Logger must implement Debug, Info, Warn, and Error methods.
+// Wrap your slog.Logger (or any compatible logger) with ecs.NewSlogAdapter
 logger := ecs.NewSlogAdapter(slog.Default())
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,40 @@
 A Go package for running callback tasks that interact with AWS Step Functions, with built-in support for heartbeats and spot instance interruption handling. Designed for use in ECS or EC2 environments where Step Functions' callback patterns are required.
 
 ## Features
-- Sends heartbeats to AWS Step Functions to prevent task timeout
-- Handles spot instance interruption notifications (EC2 Spot/Fargate)
-- Retries on failure for heartbeats, success, and failure signals
-- Simple function registration and execution pattern
+- **Heartbeat Support:** Automatically sends heartbeats to AWS Step Functions to prevent task timeout.
+- **Spot Instance Interruption Handling:** Detects and gracefully handles EC2 Spot and Fargate interruption notifications.
+- **Retry Logic:** Retries heartbeats, success, and failure signals with exponential backoff.
+- **Context Propagation:** All operations are context-aware, supporting cancellation and timeouts.
+- **Pluggable Logging:** Use any logger that implements a simple interface, or use the built-in no-op logger.
+- **Simple Worker Registration:** Register your own function to be executed as the callback task.
+- **Minimal Dependencies:** Only depends on AWS SDK v2 and standard Go libraries.
 
 ## Installation
 
 ```
 go get github.com/dalir/aws-callback-task
 ```
+
+## Logger Integration
+
+This package is decoupled from any specific logging library. You can use any logger that implements the following interface:
+
+```go
+// ecs.Logger interface
+Debug(msg string, args ...any)
+Info(msg string, args ...any)
+Warn(msg string, args ...any)
+Error(msg string, args ...any)
+```
+
+A convenience adapter for Go's slog is provided:
+
+```go
+// Wrap your slog.Logger with ecs.NewSlogAdapter
+logger := ecs.NewSlogAdapter(slog.Default())
+```
+
+If you do not provide a logger, a no-op logger will be used and no logs will be emitted.
 
 ## Minimal Usage Example
 
@@ -33,9 +57,10 @@ func main() {
         panic(err)
     }
 
-    // Create the callback task
+    // Create the callback task with slog logger
+    logger := ecs.NewSlogAdapter(slog.Default())
     task := &ecs.CallbackTask{
-        Log:        slog.Default(),
+        Log:        logger, // Any logger implementing ecs.Logger
         Token:      "<STEP_FUNCTIONS_TASK_TOKEN>",
         HBInterval: "60s", // Heartbeat every 60 seconds
         AWSCfg:     cfg,

--- a/README.md
+++ b/README.md
@@ -85,3 +85,10 @@ func main() {
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+
+## Import Example
+
+```go
+import "github.com/dalir/aws-callback-task/ecs"
+// ... uses ecs.Logger, etc.
+```

--- a/ecs/logger.go
+++ b/ecs/logger.go
@@ -8,27 +8,19 @@ type Logger interface {
 	Error(msg string, args ...any)
 }
 
-// Slogger is a minimal interface matching the required slog.Logger methods.
-type Slogger interface {
-	Debug(msg string, args ...any)
-	Info(msg string, args ...any)
-	Warn(msg string, args ...any)
-	Error(msg string, args ...any)
-}
-
-// SlogAdapter adapts a Slogger to the Logger interface.
+// SlogAdapter adapts a Logger to the Logger interface.
 type SlogAdapter struct {
-	slogger Slogger
+	logger Logger
 }
 
-func NewSlogAdapter(slogger Slogger) *SlogAdapter {
-	return &SlogAdapter{slogger: slogger}
+func NewSlogAdapter(logger Logger) *SlogAdapter {
+	return &SlogAdapter{logger: logger}
 }
 
-func (a *SlogAdapter) Debug(msg string, args ...any) { a.slogger.Debug(msg, args...) }
-func (a *SlogAdapter) Info(msg string, args ...any)  { a.slogger.Info(msg, args...) }
-func (a *SlogAdapter) Warn(msg string, args ...any)  { a.slogger.Warn(msg, args...) }
-func (a *SlogAdapter) Error(msg string, args ...any) { a.slogger.Error(msg, args...) }
+func (a *SlogAdapter) Debug(msg string, args ...any) { a.logger.Debug(msg, args...) }
+func (a *SlogAdapter) Info(msg string, args ...any)  { a.logger.Info(msg, args...) }
+func (a *SlogAdapter) Warn(msg string, args ...any)  { a.logger.Warn(msg, args...) }
+func (a *SlogAdapter) Error(msg string, args ...any) { a.logger.Error(msg, args...) }
 
 // noopLogger is a Logger implementation that does nothing (for default fallback)
 type noopLogger struct{}

--- a/ecs/logger.go
+++ b/ecs/logger.go
@@ -1,6 +1,7 @@
 package ecs
 
 // Logger is a minimal logging interface for decoupling from any specific logging library.
+// Any logger that implements these methods can be used with this package.
 type Logger interface {
 	Debug(msg string, args ...any)
 	Info(msg string, args ...any)
@@ -8,24 +9,41 @@ type Logger interface {
 	Error(msg string, args ...any)
 }
 
-// SlogAdapter adapts a Logger to the Logger interface.
+// SlogAdapter adapts a Logger (such as slog.Logger) to the Logger interface used by this package.
+// This allows you to use Go's slog or any compatible logger with aws-callback-task.
 type SlogAdapter struct {
 	logger Logger
 }
 
+// NewSlogAdapter wraps a Logger (such as slog.Logger) to conform to the Logger interface.
 func NewSlogAdapter(logger Logger) *SlogAdapter {
 	return &SlogAdapter{logger: logger}
 }
 
+// Debug logs a debug-level message using the underlying logger.
 func (a *SlogAdapter) Debug(msg string, args ...any) { a.logger.Debug(msg, args...) }
-func (a *SlogAdapter) Info(msg string, args ...any)  { a.logger.Info(msg, args...) }
-func (a *SlogAdapter) Warn(msg string, args ...any)  { a.logger.Warn(msg, args...) }
+
+// Info logs an info-level message using the underlying logger.
+func (a *SlogAdapter) Info(msg string, args ...any) { a.logger.Info(msg, args...) }
+
+// Warn logs a warning-level message using the underlying logger.
+func (a *SlogAdapter) Warn(msg string, args ...any) { a.logger.Warn(msg, args...) }
+
+// Error logs an error-level message using the underlying logger.
 func (a *SlogAdapter) Error(msg string, args ...any) { a.logger.Error(msg, args...) }
 
-// noopLogger is a Logger implementation that does nothing (for default fallback)
+// noopLogger is a Logger implementation that does nothing.
+// It is used as a default when no logger is provided, so no logs are emitted.
 type noopLogger struct{}
 
+// Debug is a no-op for noopLogger.
 func (n *noopLogger) Debug(msg string, args ...any) {}
-func (n *noopLogger) Info(msg string, args ...any)  {}
-func (n *noopLogger) Warn(msg string, args ...any)  {}
+
+// Info is a no-op for noopLogger.
+func (n *noopLogger) Info(msg string, args ...any) {}
+
+// Warn is a no-op for noopLogger.
+func (n *noopLogger) Warn(msg string, args ...any) {}
+
+// Error is a no-op for noopLogger.
 func (n *noopLogger) Error(msg string, args ...any) {}

--- a/ecs/logger.go
+++ b/ecs/logger.go
@@ -1,0 +1,48 @@
+package ecs
+
+// Logger is a minimal logging interface for decoupling from any specific logging library.
+type Logger interface {
+	Debug(msg string, args ...any)
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
+	Error(msg string, args ...any)
+}
+
+// SlogAdapter adapts slog.Logger to the Logger interface.
+type SlogAdapter struct {
+	slogger any // use any to avoid direct slog import here
+}
+
+func NewSlogAdapter(slogger any) *SlogAdapter {
+	return &SlogAdapter{slogger: slogger}
+}
+
+func (a *SlogAdapter) Debug(msg string, args ...any) {
+	// type assertion to *slog.Logger
+	if l, ok := a.slogger.(interface{ Debug(string, ...any) }); ok {
+		l.Debug(msg, args...)
+	}
+}
+func (a *SlogAdapter) Info(msg string, args ...any) {
+	if l, ok := a.slogger.(interface{ Info(string, ...any) }); ok {
+		l.Info(msg, args...)
+	}
+}
+func (a *SlogAdapter) Warn(msg string, args ...any) {
+	if l, ok := a.slogger.(interface{ Warn(string, ...any) }); ok {
+		l.Warn(msg, args...)
+	}
+}
+func (a *SlogAdapter) Error(msg string, args ...any) {
+	if l, ok := a.slogger.(interface{ Error(string, ...any) }); ok {
+		l.Error(msg, args...)
+	}
+}
+
+// noopLogger is a Logger implementation that does nothing (for default fallback)
+type noopLogger struct{}
+
+func (n *noopLogger) Debug(msg string, args ...any) {}
+func (n *noopLogger) Info(msg string, args ...any)  {}
+func (n *noopLogger) Warn(msg string, args ...any)  {}
+func (n *noopLogger) Error(msg string, args ...any) {}

--- a/ecs/logger.go
+++ b/ecs/logger.go
@@ -8,36 +8,27 @@ type Logger interface {
 	Error(msg string, args ...any)
 }
 
-// SlogAdapter adapts slog.Logger to the Logger interface.
-type SlogAdapter struct {
-	slogger any // use any to avoid direct slog import here
+// Slogger is a minimal interface matching the required slog.Logger methods.
+type Slogger interface {
+	Debug(msg string, args ...any)
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
+	Error(msg string, args ...any)
 }
 
-func NewSlogAdapter(slogger any) *SlogAdapter {
+// SlogAdapter adapts a Slogger to the Logger interface.
+type SlogAdapter struct {
+	slogger Slogger
+}
+
+func NewSlogAdapter(slogger Slogger) *SlogAdapter {
 	return &SlogAdapter{slogger: slogger}
 }
 
-func (a *SlogAdapter) Debug(msg string, args ...any) {
-	// type assertion to *slog.Logger
-	if l, ok := a.slogger.(interface{ Debug(string, ...any) }); ok {
-		l.Debug(msg, args...)
-	}
-}
-func (a *SlogAdapter) Info(msg string, args ...any) {
-	if l, ok := a.slogger.(interface{ Info(string, ...any) }); ok {
-		l.Info(msg, args...)
-	}
-}
-func (a *SlogAdapter) Warn(msg string, args ...any) {
-	if l, ok := a.slogger.(interface{ Warn(string, ...any) }); ok {
-		l.Warn(msg, args...)
-	}
-}
-func (a *SlogAdapter) Error(msg string, args ...any) {
-	if l, ok := a.slogger.(interface{ Error(string, ...any) }); ok {
-		l.Error(msg, args...)
-	}
-}
+func (a *SlogAdapter) Debug(msg string, args ...any) { a.slogger.Debug(msg, args...) }
+func (a *SlogAdapter) Info(msg string, args ...any)  { a.slogger.Info(msg, args...) }
+func (a *SlogAdapter) Warn(msg string, args ...any)  { a.slogger.Warn(msg, args...) }
+func (a *SlogAdapter) Error(msg string, args ...any) { a.slogger.Error(msg, args...) }
 
 // noopLogger is a Logger implementation that does nothing (for default fallback)
 type noopLogger struct{}

--- a/ecs/wrapper.go
+++ b/ecs/wrapper.go
@@ -16,9 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
 )
 
-// import "github.com/dalir/aws-callback-task/ecs"
-// ... uses ecs.Logger, etc.
-
 // Fn defines a function type that returns a string and an error.
 type Fn func(ctx context.Context) (string, error)
 

--- a/ecs/wrapper.go
+++ b/ecs/wrapper.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -16,6 +15,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
 )
+
+// import "github.com/dalir/aws-callback-task/ecs"
+// ... uses ecs.Logger, etc.
 
 // Fn defines a function type that returns a string and an error.
 type Fn func(ctx context.Context) (string, error)
@@ -40,10 +42,10 @@ type CallbackOutput struct {
 // CallbackTask handles the execution of a task that communicates
 // with AWS Step Functions and handles spot instance interruptions.
 type CallbackTask struct {
-	Log                *slog.Logger // Logger for logging events.
-	Token              string       // Task token for communicating with AWS Step Functions.
-	HBInterval         string       // Heartbeat interval duration string. A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-	CheckSpotInterrupt bool         // Flag to check for spot instance interruptions.
+	Log                Logger // Logger for logging events.
+	Token              string // Task token for communicating with AWS Step Functions.
+	HBInterval         string // Heartbeat interval duration string. A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	CheckSpotInterrupt bool   // Flag to check for spot instance interruptions.
 	AWSCfg             aws.Config
 	sfnClient          *sfn.Client         // AWS Step Functions client.
 	hbTicker           *time.Ticker        // Ticker for sending heartbeats.
@@ -217,10 +219,9 @@ func (ct *CallbackTask) sendFailure(ctx context.Context, errMsg error) {
 // checking for spot interruptions, and handling the task execution result.
 func (ct *CallbackTask) Run(ctx context.Context) {
 	ct.sfnClient = sfn.NewFromConfig(ct.AWSCfg)
+	// If no logger is provided, use a no-op logger
 	if ct.Log == nil {
-		ct.Log = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-			Level: slog.LevelDebug,
-		}))
+		ct.Log = &noopLogger{}
 	}
 	ct.returnChan = make(chan CallbackOutput, 10)
 	ct.sigsChan = make(chan os.Signal, 1)


### PR DESCRIPTION
## Summary
This PR decouples logging from any specific library by introducing a minimal `Logger` interface, provides a `SlogAdapter` for easy integration with Go's slog, and moves all logger abstractions to a dedicated file. The README is updated with clear features, logger usage, and integration instructions.

### Changes:
- Introduced a `Logger` interface for pluggable logging.
- Added `SlogAdapter` for Go's slog and a no-op logger fallback.
- Moved logger abstractions to `ecs/logger.go`.
- Updated README with a detailed features section and logger usage instructions.
- Updated usage example to show how to use the logger interface.

### Motivation
This makes the module more flexible, testable, and easier to integrate into any Go application, regardless of its logging strategy.