### PR TITLE
fix: reset heartbeat retry counter on success

### DIFF
--- a/ecs/wrapper.go
+++ b/ecs/wrapper.go
@@ -78,6 +78,7 @@ func (ct *CallbackTask) sendHeartbeat(ctx context.Context) {
 			}
 		}
 	} else {
+		ct.hbRetryCounter = 0
 		rec := log.Record{}
 		rec.SetTimestamp(time.Now())
 		rec.SetSeverity(log.SeverityInfo)


### PR DESCRIPTION
## Summary
- Adds `ct.hbRetryCounter = 0` in the success branch of `sendHeartbeat`
- Prevents a transient failure from permanently consuming a retry slot for the rest of the task's lifetime

## Dependencies
Depends on #10 (retry counters as struct fields) — merge that first.

## Test plan
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes