### PR TITLE
fix: add return after wg.Done to prevent panic and goroutine leak

### DIFF
--- a/ecs/wrapper.go
+++ b/ecs/wrapper.go
@@ -317,9 +317,11 @@ func (ct *CallbackTask) Run(ctx context.Context) {
 					rec.AddAttributes(log.String("error", callbackOutput.Err.Error()))
 					ct.Logger.Emit(ctx, rec)
 					wg.Done()
+					return
 				}
 				ct.sendSuccess(ctx, callbackOutput.JsonOutput)
 				wg.Done()
+				return
 			case <-ct.hbTicker.C:
 				go ct.sendHeartbeat(ctx)
 			case <-ct.siTicker.C:


### PR DESCRIPTION
## Summary
- Adds `return` after `wg.Done()` in the error branch of the `returnChan` select case — prevents fall-through to `sendSuccess` and a second `wg.Done()` that would panic with `sync: negative WaitGroup counter`
- Adds `return` after `wg.Done()` in the success branch — stops the goroutine's `for` loop from spinning forever after the task completes (goroutine leak)

## Dependencies
Depends on #10 → #11 → #12 → #13 chain for a clean merge, though this fix is self-contained on the two `return` additions.

## Test plan
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Manually verify: task with a failing worker no longer panics; task with a succeeding worker exits cleanly